### PR TITLE
fix: 포스트 상세 화면 이동 시 발생하던 화면 새로고침 해결

### DIFF
--- a/src/components/post-item.tsx
+++ b/src/components/post-item.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { css, jsx, SerializedStyles } from '@emotion/core'
 import dayjs from 'dayjs'
+import { Link } from 'gatsby'
 import _ from 'lodash/fp'
 
 import { ALPHA, PNG } from '../constants'
@@ -16,7 +17,7 @@ const PostItem: React.FC<Props> = ({ post }) => {
 
   return (
     <li css={s.postItem}>
-      <a css={s.anchorBlock} href={post.node.fields.slug}>
+      <Link css={s.link} to={post.node.fields.slug}>
         <h3 css={s.heading}>
           {post.node.frontmatter.title}
         </h3>
@@ -58,7 +59,7 @@ const PostItem: React.FC<Props> = ({ post }) => {
             ), post.node.frontmatter.tags)}
           </ul>
         </div>
-      </a>
+      </Link>
     </li>
   )
 }
@@ -83,7 +84,7 @@ const s = {
     color: ${theme.palette.grey[500]};
     font-size: ${theme.typography.pxToRem(14)};
   `,
-  anchorBlock: (theme: Theme): SerializedStyles => css`
+  link: (theme: Theme): SerializedStyles => css`
     display: flex;
     flex-direction: column;
     width: 100%;


### PR DESCRIPTION
포스트 목록 화면에서 포스트 상세 화면 링크로
`a` 태그를 사용하고 있어 클라이언트 사이드 라우팅 방식으로
동작하지 않고 있었고 이 부분을 `Link` 태그로 변경하여 문제를 해결함

Resolved #30