### PR TITLE
feat: 블로그 메타데이터 변경

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -7,7 +7,8 @@ const currentYear = new Date().getFullYear()
 
 module.exports = {
   siteMetadata: {
-    title: 'CHNY',
+    name: 'CHNY',
+    title: 'CHNY.WORLD',
     description: '개발자 김찬연 TECH 블로그',
     image: 'https://repository-images.githubusercontent.com/238482693/10065400-563f-11ea-9f76-928d767a061d',
     author: '김찬연',

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -16,7 +16,7 @@ const Layout: React.FC<Props> = ({ children }) => {
     query SiteTitleQuery {
       site {
         siteMetadata {
-          title
+          name
         }
       }
     }
@@ -25,7 +25,7 @@ const Layout: React.FC<Props> = ({ children }) => {
   return (
     <div css={s.root}>
       <SkipLink />
-      <Header siteTitle={data.site.siteMetadata.title} />
+      <Header siteTitle={data.site.siteMetadata.name} />
       <div css={s.wrapper}>
         <main id={CONTENT_LINK} css={s.main}>{children}</main>
         <Footer />

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -8,7 +8,7 @@ interface Props {
   lang?: string;
   link?: any[];
   meta?: any[];
-  title: string;
+  title?: string;
   type?: 'website' | 'article';
   url?: string;
 }
@@ -52,6 +52,7 @@ const SEO: React.FC<Props> = ({
   return (
     <Helmet
       htmlAttributes={{ lang }}
+      defaultTitle={site.siteMetadata.title}
       title={title}
       titleTemplate={`%s | ${site.siteMetadata.title as string}`}
       link={[
@@ -75,7 +76,7 @@ const SEO: React.FC<Props> = ({
         },
         {
           property: 'og:title',
-          content: title,
+          content: title ? `${title} | ${site.siteMetadata.title as string}` : site.siteMetadata.title,
         },
         {
           property: 'og:description',

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -63,7 +63,7 @@ const AboutPage: React.FC<Props> = ({ data, location }) => {
   return (
     <Layout>
       <SEO
-        title="About"
+        title="소개"
         url={`${data.site.siteMetadata.siteUrl}${location.pathname}`}
         meta={meta}
       />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -41,7 +41,6 @@ const HomePage: React.FC<Props> = ({ data, location }) => {
   return (
     <Layout>
       <SEO
-        title="CHNY Blog"
         url={`${data.site.siteMetadata.siteUrl}${location.pathname}`}
         meta={meta}
       />


### PR DESCRIPTION
- 블로그 탭에 보여지는 타이틀을 'CHNY.WORLD'로 변경하고 로고 텍스트는 'CHNY'를 그대로 유지하기 위해 'gatsby-config.js'에 `siteMetadata.name` 필드를 추가함
- 브라우저 탭의 타이틀 및 SNS 공유 시 보여질 타이틀의 형식을 변경
  - 홈 화면: CHNY.WORLD
  - 그 외: {제목} | CHNY.WORLD

Resolves #51