### PR TITLE
fix(rss): rss 링크 접속 시 발생하던 에러 해결

### DIFF
--- a/src/posts/containing-block.mdx
+++ b/src/posts/containing-block.mdx
@@ -37,7 +37,7 @@ cover: './covers/containing-block.jpg'
    3. `filter` 속성 값이 `none`인 경우 (Firefox에선 `will-change`가 `filter`일 때도 적용)
    4. `contain` 속성 값이 `paint`인 경우
 
-> 루트 요소(`<html>`)의 컨테이닝 블록은 초기 컨테이닝 블록이라고 불리는 사각형이다. 초기 컨테이닝 블록은 뷰포트 영역 또는 (페이지로 나뉘는 미디어에선) 페이지 영역의 크기와 같다.
+> 루트 요소(`<html>`)의 컨테이닝 블록은 초기 컨테이닝 블록이라고 불리는 사각형이다. 초기 컨테이닝 블록은 뷰포트 영역 또는 (페이지로 나뉘는 미디어에선) 페이지 영역의 크기와 같다.
 
 ## 컨테이닝 블록으로부터 백분율 값 계산하기 {#calculating-percentage-values-from-the-containing-block}
 


### PR DESCRIPTION
RSS 링크 접속 시 "error on line 49 at column 30968: PCDATA invalid Char
value 29" 에러가 발생하고 있었고, 검색해본 결과 MDX 문서 내에
사람의 눈으로 식별할 수 없는 특수 문자가 포함되어 발생했던
문제임을 확인함. 이에 따라 `containg-block.mdx` 문서 내에 포함되어 있던
특수 문자를 제거하여 문제를 해결함

(참고: https://ju3un.github.io/webmaster-rss-error/)

Resolves #26