### PR TITLE
chore: 네이버 웹마스터에서 사이트 소유 확인을 위한 HTML 파일 추가

### DIFF
--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -190,10 +190,6 @@ const SEO: React.FC<Props> = ({
           name: 'apple-mobile-web-app-status-bar-style',
           content: 'default',
         },
-        {
-          name: 'naver-site-verification',
-          content: process.env.GATSBY_NAVER_SITE_VERIFICATION_KEY,
-        },
       ].concat(meta)}
     />
   )

--- a/static/naverbe18554e2b1e6f231caa5ae88c809514.html
+++ b/static/naverbe18554e2b1e6f231caa5ae88c809514.html
@@ -1,0 +1,1 @@
+naver-site-verification: naverbe18554e2b1e6f231caa5ae88c809514.html


### PR DESCRIPTION
네이버 웹마스터에서 HTML 메타태그를 통한 소유 확인이 적용되지 않는 문제로 HTML 파일 업로드를 통한 방법으로 변경함

