### PR TITLE
fix: 컬러 모드 변경에 맞춰 브라우저 상단 바 색상도 함께 변경하도록 수정

### DIFF
--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -1,8 +1,10 @@
+import { useTheme } from 'emotion-theming'
 import { graphql, useStaticQuery } from 'gatsby'
 import React from 'react'
 import Helmet from 'react-helmet'
 
 import { splash } from '../assets/images'
+import { Theme } from '../models/Theme'
 
 interface Props {
   description?: string;
@@ -46,6 +48,8 @@ const SEO: React.FC<Props> = ({
       }
     `,
   )
+
+  const theme: Theme = useTheme()
 
   const metaDescription = description || site.siteMetadata.description
   const metaImage = image || site.siteMetadata.image
@@ -189,6 +193,10 @@ const SEO: React.FC<Props> = ({
         {
           name: 'apple-mobile-web-app-status-bar-style',
           content: 'default',
+        },
+        {
+          name: 'theme-color',
+          content: theme.palette.background.paper,
         },
       ].concat(meta)}
     />


### PR DESCRIPTION
컬러 모드 변경에 맞춰 `theme-color` meta 태그의 값을 변경하는 작업이 #53에서 누락되어 브라우저 상단 바 색상이 변경되지 않는 문제가 발생했고, 이에 대한 문제를 해결함

Resolves #79 