### PR TITLE
fix: 섹션 제목에 포함된 코드 블럭인 경우 폰트 크기를 유지하도록 수정

### DIFF
--- a/src/styles/mdx/light.ts
+++ b/src/styles/mdx/light.ts
@@ -48,6 +48,15 @@ const light = css`
     overflow: -moz-scrollbars-none;
   }
 
+  h1 > code[class*='language-'],
+  h2 > code[class*='language-'],
+  h3 > code[class*='language-'],
+  h4 > code[class*='language-'],
+  h5 > code[class*='language-'],
+  h6 > code[class*='language-'] {
+    font-size: inherit;
+  }
+
   pre[class*='language-']::-webkit-scrollbar {
     display: none;
   }


### PR DESCRIPTION
 인라인 코드 블록이 적용된 제목에 대해서도 정상 폰트 크기로 렌더링하도록 변경

Resolves #64