### PR TITLE
fix: sns 공유 시 공유 url이 들어있지 않던 문제 해결

### DIFF
--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -138,7 +138,7 @@ const BlogPost: React.FC<Props> = ({ data, location, pageContext }) => {
           <footer>
             <SocialShare
               frontmatter={data.mdx.frontmatter}
-              url={location.href}
+              url={`${data.site.siteMetadata.siteUrl}${location.pathname}`}
             />
             <Profile css={s.profile} />
             <PostNavigation pageContext={pageContext} />


### PR DESCRIPTION
빌드 타임에 `location.href`가 존재하지 않아 sns 공유 링크 클릭시 공유 url이 `undefined`인 문제가 있었고 `siteMetadata.siteUrl`과 `location.pathname`을 조합하여 url을 구성하게 함으로써 문제를 해결함

Resolves #95