### PR TITLE
fix: ie11 관련 버그 수정

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -151,7 +151,7 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-polyfill-io',
       options: {
-         features: ['IntersectionObserver'],
+         features: ['IntersectionObserver', 'document'],
       },
    },
     'gatsby-plugin-react-helmet',


### PR DESCRIPTION
`HTMLElement.current`와 `HTMLElement.appendChild` 지원을 위한 polyfiil을 추가함

Resolves #83